### PR TITLE
JSON parse would throw an exception in case of empty response, which …

### DIFF
--- a/ruby/ScalrAPI.rb
+++ b/ruby/ScalrAPI.rb
@@ -73,7 +73,9 @@ class ScalrAPI
 			:headers => headers,
 			:payload  => body
 		)
-		
+		if response == ""
+			response = "{}"
+		end
 		return JSON.parse(response)
 	
 	end


### PR DESCRIPTION
…can happen because of a delete call